### PR TITLE
fix: drop removed rq.Connection import for RQ 2.x / Python 3.14 compat

### DIFF
--- a/spine/spine_adapter/redis_client/redis_client.py
+++ b/spine/spine_adapter/redis_client/redis_client.py
@@ -7,7 +7,6 @@ import uuid
 from logging.handlers import RotatingFileHandler
 
 import redis
-from rq import Connection
 from rq.logutils import setup_loghandlers
 
 import frappe
@@ -138,10 +137,9 @@ def worker(site, queue, type="json", quiet=False, log=None):
         redis_connection = get_redis_conn()
         if os.environ.get('CI'):
             setup_loghandlers('ERROR')
-        with Connection(redis_connection):
-            logging_level = "INFO"
-            if quiet:
-                logging_level = "WARNING"
+        logging_level = "INFO"
+        if quiet:
+            logging_level = "WARNING"
         q = get_redis_queue(queue)
         # if q.get_length() > 0:
         q.dequeue_and_execute(logging_level, log, site)


### PR DESCRIPTION
Newer RQ (2.x, shipped on the frappe-16 / Python 3.14 stack) removed the top-level `Connection` context manager. spine's `redis_client.worker` still does `from rq import Connection` and wraps its body in `with Connection(redis_connection):`, so `install-app spine` crashes on import with `cannot import name 'Connection' from 'rq'`.

This removes the import and the `with` wrapper (the connection is already resolved via `get_redis_conn()` / `get_redis_queue()`), unblocking spine on v16 while remaining a no-op on older RQ.

Verified: `py_compile` passes; spine imports and installs on a frappe-16 bench (Python 3.14, RQ 2.6.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)